### PR TITLE
fix: no only suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,13 @@ module.exports = {
                 }
             }
         ],
-        "no-only-tests/no-only-tests": "warn",
+        "no-only-tests/no-only-tests": [
+            "warn",
+            {
+                "block": ["test", "suite", "assert"],
+                "focus": ["only"],
+            }
+        ],
         "no-console": "warn"
     }
 }


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Because mocha allows `suite.only` as well as `test.only`.

<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
